### PR TITLE
Fix typo

### DIFF
--- a/social-login.scss
+++ b/social-login.scss
@@ -128,7 +128,7 @@ button.sb {
     & {
       color: $font-color !important;
     }
-    &::hover {
+    &:hover {
       color: $font-color !important;
     }
   }


### PR DESCRIPTION
The extra colon broke the generation of the CSS file on my Linux server. For some reason it worked ok on my Mac... ¯\_(ツ)_/¯